### PR TITLE
Add support for X SILENT Edge Platinum 1100 (0x020C)

### DIFF
--- a/cm-psu.c
+++ b/cm-psu.c
@@ -2,9 +2,22 @@
 /*
  * cm-psu.c - Linux driver for Cooler Master power supplies with HID interface
  * Copyright (C) 2023 Jannis Mast <jannis@ctrl-c.xyz>
- * 
+ *
  * Based on corsair-psu.c
  * Copyright (C) 2020 Wilken Gottwalt <wilken.gottwalt@posteo.net>
+ *
+ * X SILENT Edge Platinum support (PID 0x020C) added 2026.
+ * That model speaks a DIFFERENT protocol than the MasterPlus devices:
+ *  - Binary (not ASCII), little-endian values
+ *  - Report 3 (23 bytes incl. report-id) = full telemetry, streamed by the
+ *    device on its own (no request needed)
+ *  - Report 4 (2 bytes incl. report-id)  = hotspot temperature in degC
+ * Layout of report 3 payload (data[1..22], data[0] = report id 0x03):
+ *   [0,1] u16 Vin/10   [2] u8 Iin/10   [3,4] u16 Pin   [5,6] u16 Pout
+ *   [7] u8 V12/10      [8,9] u16 I12/10    [10,11] u16 P12
+ *   [12] u8 V3.3/10    [13,14] u16 I3.3/10 [15,16] u16 P3.3
+ *   [17] u8 V5/10      [18,19] u16 I5/10   [20,21] u16 P5
+ * Verified against MasterCTRL/HWiNFO and via P = U*I on all rails.
  */
 
 #include <linux/errno.h>
@@ -16,51 +29,21 @@
 #include <linux/types.h>
 
 /*
- * Protocol information:
+ * MasterPlus protocol information (unchanged):
  * - The PSU sends HID events without having to send a request first
- * - Events contain human-readable strings
- * - All events appear to be 16 bytes long, padded with zero bytes if needed
- * - The format of each string is:
- *   [{type}{channel}{value}]
- * - Types are a single uppercase letter, channels a single digit
- * - Valid types are:
- *   - V: Voltage (Volt)
- *   - I: Current (Amp)
- *   - P: Power (Watt)
- *   - T: Temperature (°C)
- *   - R: Fan speed (RPM)
- * - Channels start at 1
- * - Values can have different numbers of digits and can include a decimal
- *   point
- * - Special case: Channel P2 includes two values in this format:
- *   [P2{value1}/{value2}]
- *   (No other channels appear to do this)
- * 
- * The protocol has been reverse engineered (if you can even call it that) by
- * looking at the data and referecing with what is displayed by Cooler Master's
- * "MasterPlus" software.
- * The driver has been tested against a V850 Gold i multi PSU. Looking at
- * hardware description files (JSON) included with MasterPlus, all compatible
- * models should use an identical protocol.
- * 
- * Quirks/missing features:
- * - The temperature readings don't have labels because there is no indication
- *   what they acutally are. CM's software only show one temperature.
- * - Channel P1 is currently ignored because it is unclear what value it is
- *   reporting. Looking at the previously mentioned JSON files from MasterPlus,
- *   it is either PFC (Power factor correction?) or EFF (efficiency?). CM's
- *   software doesn't show this value either.
- * - Fan control is not supported. Right now, this driver is entirely passive
- *   and does not send any requests to the PSU. Figuring out the protocol for
- *   setting custom fan curves will likely require sniffing USB traffic from
- *   CM's software (which refuses to run on my machine for some reason).
- * - The XG650/750/850 PSUs may also use the same protocol as they are
- *   supported by MasterPlus - However, those have different sets of channels/
- *   sensors additional code may be needed
+ * - Events contain human-readable strings of the form [{type}{channel}{value}]
+ *   (see original driver comment for full details)
  */
 
 #define DRIVER_NAME "cm-psu"
 
+/* protocol selector, stored per device via hid_device_id.driver_data */
+enum cmpsu_proto {
+	CMPSU_MASTERPLUS = 0,
+	CMPSU_XSILENT    = 1,
+};
+
+/* ---- MasterPlus counts (original) ---- */
 #define COUNT_VOLTAGE 5
 #define COUNT_CURRENT 5
 #define COUNT_POWER   2
@@ -69,17 +52,37 @@
 
 #define EVENT_LEN 16
 
+/* ---- X SILENT counts ---- */
+#define XS_COUNT_VOLTAGE 4	/* V_AC, +12V, +3.3V, +5V */
+#define XS_COUNT_CURRENT 4	/* I_AC, I_+12V, I_+3.3V, I_+5V */
+#define XS_COUNT_POWER   5	/* P_in, P_out, P_+12V, P_+3.3V, P_+5V */
+#define XS_COUNT_TEMP    1
+
+#define XS_REPORT_DATA 0x03
+#define XS_REPORT_TEMP 0x04
+#define XS_LEN_DATA    23
+#define XS_LEN_TEMP    2
+
 struct cmpsu_data {
 	struct hid_device *hdev;
 	struct device *hwmon_dev;
+	int proto;
+	/* MasterPlus values */
 	long values_voltage[COUNT_VOLTAGE];
 	long values_current[COUNT_CURRENT];
 	long values_power[COUNT_POWER];
 	long values_temp[COUNT_TEMP];
 	long values_fan[COUNT_FAN];
+	/* X SILENT values */
+	long xs_in[XS_COUNT_VOLTAGE];
+	long xs_curr[XS_COUNT_CURRENT];
+	long xs_power[XS_COUNT_POWER];
+	long xs_temp[XS_COUNT_TEMP];
 };
 
-static const char* cmpsu_labels_voltage[] = {
+/* =========================== MasterPlus path =========================== */
+
+static const char *cmpsu_labels_voltage[] = {
 	"V_AC",
 	"+5V",
 	"+3.3V",
@@ -88,7 +91,7 @@ static const char* cmpsu_labels_voltage[] = {
 	"+12V1",
 };
 
-static const char* cmpsu_labels_current[] = {
+static const char *cmpsu_labels_current[] = {
 	"I_AC",
 	"I_+5V",
 	"I_+3.3V",
@@ -96,16 +99,13 @@ static const char* cmpsu_labels_current[] = {
 	"I_+12V1",
 };
 
-static const char* cmpsu_labels_power[] = {
+static const char *cmpsu_labels_power[] = {
 	"P_in",
 	"P_out",
 };
 
-/*long cmpsu_parse_value(u8 *data, int *idx, int fraction_scale,
-			bool expect_second);*/
-
 static umode_t cmpsu_hwmon_is_visible(const void *data,
-			enum hwmon_sensor_types type, u32 attr, int channel)
+		enum hwmon_sensor_types type, u32 attr, int channel)
 {
 	switch (type) {
 		case hwmon_in:
@@ -131,16 +131,16 @@ static umode_t cmpsu_hwmon_is_visible(const void *data,
 		default:
 			break;
 	}
-	
+
 	return 0;
 }
 
 static int cmpsu_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
-			u32 attr, int channel, long *val)
+		u32 attr, int channel, long *val)
 {
 	struct cmpsu_data *priv = dev_get_drvdata(dev);
 	int err = -EOPNOTSUPP;
-	
+
 	switch (type) {
 		case hwmon_in:
 			if (channel < COUNT_VOLTAGE) {
@@ -195,13 +195,13 @@ static int cmpsu_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
 		default:
 			break;
 	}
-	
+
 	return err;
 }
 
 static int cmpsu_hwmon_read_string(struct device *dev,
-			enum hwmon_sensor_types type, u32 attr,
-			int channel, const char **str)
+		enum hwmon_sensor_types type, u32 attr,
+		int channel, const char **str)
 {
 	if (type == hwmon_in && attr == hwmon_in_label \
 	    && channel < COUNT_VOLTAGE) {
@@ -216,7 +216,7 @@ static int cmpsu_hwmon_read_string(struct device *dev,
 		*str = cmpsu_labels_power[channel];
 		return 0;
 	}
-	
+
 	return -EOPNOTSUPP;
 }
 
@@ -226,27 +226,27 @@ static const struct hwmon_ops cmpsu_hwmon_ops = {
 	.read_string = cmpsu_hwmon_read_string,
 };
 
-static const struct hwmon_channel_info* cmpsu_info[] = {
+static const struct hwmon_channel_info *cmpsu_info[] = {
 	HWMON_CHANNEL_INFO(temp,
-					HWMON_T_INPUT,
-					HWMON_T_INPUT),
+				HWMON_T_INPUT,
+				HWMON_T_INPUT),
 	HWMON_CHANNEL_INFO(fan,
-					HWMON_F_INPUT),
+				HWMON_F_INPUT),
 	HWMON_CHANNEL_INFO(in,
-					HWMON_I_INPUT | HWMON_I_LABEL,
-					HWMON_I_INPUT | HWMON_I_LABEL,
-					HWMON_I_INPUT | HWMON_I_LABEL,
-					HWMON_I_INPUT | HWMON_I_LABEL,
-					HWMON_I_INPUT | HWMON_I_LABEL),
+				HWMON_I_INPUT | HWMON_I_LABEL,
+				HWMON_I_INPUT | HWMON_I_LABEL,
+				HWMON_I_INPUT | HWMON_I_LABEL,
+				HWMON_I_INPUT | HWMON_I_LABEL,
+				HWMON_I_INPUT | HWMON_I_LABEL),
 	HWMON_CHANNEL_INFO(curr,
-					HWMON_C_INPUT | HWMON_C_LABEL,
-					HWMON_C_INPUT | HWMON_C_LABEL,
-					HWMON_C_INPUT | HWMON_C_LABEL,
-					HWMON_C_INPUT | HWMON_C_LABEL,
-					HWMON_C_INPUT | HWMON_C_LABEL),
+				HWMON_C_INPUT | HWMON_C_LABEL,
+				HWMON_C_INPUT | HWMON_C_LABEL,
+				HWMON_C_INPUT | HWMON_C_LABEL,
+				HWMON_C_INPUT | HWMON_C_LABEL,
+				HWMON_C_INPUT | HWMON_C_LABEL),
 	HWMON_CHANNEL_INFO(power,
-					HWMON_P_INPUT | HWMON_P_LABEL,
-					HWMON_P_INPUT | HWMON_P_LABEL),
+				HWMON_P_INPUT | HWMON_P_LABEL,
+				HWMON_P_INPUT | HWMON_P_LABEL),
 	NULL
 };
 
@@ -255,76 +255,272 @@ static const struct hwmon_chip_info cmpsu_chip_info = {
 	.info = cmpsu_info,
 };
 
+/* ============================ X SILENT path ============================ */
+
+static const char *cmpsu_xs_labels_voltage[] = {
+	"V_AC", "+12V", "+3.3V", "+5V",
+};
+
+static const char *cmpsu_xs_labels_current[] = {
+	"I_AC", "I_+12V", "I_+3.3V", "I_+5V",
+};
+
+static const char *cmpsu_xs_labels_power[] = {
+	"P_in", "P_out", "P_+12V", "P_+3.3V", "P_+5V",
+};
+
+static umode_t cmpsu_xs_is_visible(const void *data,
+		enum hwmon_sensor_types type, u32 attr, int channel)
+{
+	switch (type) {
+		case hwmon_in:
+			if (channel < XS_COUNT_VOLTAGE)
+				return 0444;
+			break;
+		case hwmon_curr:
+			if (channel < XS_COUNT_CURRENT)
+				return 0444;
+			break;
+		case hwmon_power:
+			if (channel < XS_COUNT_POWER)
+				return 0444;
+			break;
+		case hwmon_temp:
+			if (channel < XS_COUNT_TEMP)
+				return 0444;
+			break;
+		default:
+			break;
+	}
+
+	return 0;
+}
+
+static int cmpsu_xs_read(struct device *dev, enum hwmon_sensor_types type,
+		u32 attr, int channel, long *val)
+{
+	struct cmpsu_data *priv = dev_get_drvdata(dev);
+
+	switch (type) {
+		case hwmon_in:
+			if (channel < XS_COUNT_VOLTAGE) {
+				if (priv->xs_in[channel] == -1)
+					return -ENODATA;
+				*val = priv->xs_in[channel];
+				return 0;
+			}
+			break;
+		case hwmon_curr:
+			if (channel < XS_COUNT_CURRENT) {
+				if (priv->xs_curr[channel] == -1)
+					return -ENODATA;
+				*val = priv->xs_curr[channel];
+				return 0;
+			}
+			break;
+		case hwmon_power:
+			if (channel < XS_COUNT_POWER) {
+				if (priv->xs_power[channel] == -1)
+					return -ENODATA;
+				*val = priv->xs_power[channel];
+				return 0;
+			}
+			break;
+		case hwmon_temp:
+			if (channel < XS_COUNT_TEMP) {
+				if (priv->xs_temp[channel] == -1)
+					return -ENODATA;
+				*val = priv->xs_temp[channel];
+				return 0;
+			}
+			break;
+		default:
+			break;
+	}
+
+	return -EOPNOTSUPP;
+}
+
+static int cmpsu_xs_read_string(struct device *dev,
+		enum hwmon_sensor_types type, u32 attr,
+		int channel, const char **str)
+{
+	if (type == hwmon_in && attr == hwmon_in_label
+	    && channel < XS_COUNT_VOLTAGE) {
+		*str = cmpsu_xs_labels_voltage[channel];
+		return 0;
+	} else if (type == hwmon_curr && attr == hwmon_curr_label
+	           && channel < XS_COUNT_CURRENT) {
+		*str = cmpsu_xs_labels_current[channel];
+		return 0;
+	} else if (type == hwmon_power && attr == hwmon_power_label
+	           && channel < XS_COUNT_POWER) {
+		*str = cmpsu_xs_labels_power[channel];
+		return 0;
+	}
+
+	return -EOPNOTSUPP;
+}
+
+static const struct hwmon_ops cmpsu_xs_hwmon_ops = {
+	.is_visible = cmpsu_xs_is_visible,
+	.read = cmpsu_xs_read,
+	.read_string = cmpsu_xs_read_string,
+};
+
+static const struct hwmon_channel_info *cmpsu_xs_info[] = {
+	HWMON_CHANNEL_INFO(temp,
+				HWMON_T_INPUT),
+	HWMON_CHANNEL_INFO(in,
+				HWMON_I_INPUT | HWMON_I_LABEL,
+				HWMON_I_INPUT | HWMON_I_LABEL,
+				HWMON_I_INPUT | HWMON_I_LABEL,
+				HWMON_I_INPUT | HWMON_I_LABEL),
+	HWMON_CHANNEL_INFO(curr,
+				HWMON_C_INPUT | HWMON_C_LABEL,
+				HWMON_C_INPUT | HWMON_C_LABEL,
+				HWMON_C_INPUT | HWMON_C_LABEL,
+				HWMON_C_INPUT | HWMON_C_LABEL),
+	HWMON_CHANNEL_INFO(power,
+				HWMON_P_INPUT | HWMON_P_LABEL,
+				HWMON_P_INPUT | HWMON_P_LABEL,
+				HWMON_P_INPUT | HWMON_P_LABEL,
+				HWMON_P_INPUT | HWMON_P_LABEL,
+				HWMON_P_INPUT | HWMON_P_LABEL),
+	NULL
+};
+
+static const struct hwmon_chip_info cmpsu_xs_chip_info = {
+	.ops = &cmpsu_xs_hwmon_ops,
+	.info = cmpsu_xs_info,
+};
+
+/* little-endian u16 from payload */
+static inline u16 cmpsu_xs_u16(const u8 *d, int i)
+{
+	return d[i] | (d[i + 1] << 8);
+}
+
+static void cmpsu_xs_parse(struct cmpsu_data *priv, u8 *data, int size)
+{
+	/* data[0] = report id; payload starts at data[1] */
+	if (data[0] == XS_REPORT_DATA && size == XS_LEN_DATA) {
+		/* voltages: byte/10 V -> millivolt = byte*100 */
+		priv->xs_in[0] = (long)cmpsu_xs_u16(data, 1) * 100; /* V_AC */
+		priv->xs_in[1] = (long)data[8] * 100;               /* +12V */
+		priv->xs_in[2] = (long)data[13] * 100;              /* +3.3V */
+		priv->xs_in[3] = (long)data[18] * 100;              /* +5V */
+		/* currents: value/10 A -> milliamp = value*100 */
+		priv->xs_curr[0] = (long)data[3] * 100;                 /* I_AC */
+		priv->xs_curr[1] = (long)cmpsu_xs_u16(data, 9) * 100;   /* I_+12V */
+		priv->xs_curr[2] = (long)cmpsu_xs_u16(data, 14) * 100;  /* I_+3.3V */
+		priv->xs_curr[3] = (long)cmpsu_xs_u16(data, 19) * 100;  /* I_+5V */
+		/* powers: watt -> microwatt = watt*1000000 */
+		priv->xs_power[0] = (long)cmpsu_xs_u16(data, 4) * 1000000;  /* P_in */
+		priv->xs_power[1] = (long)cmpsu_xs_u16(data, 6) * 1000000;  /* P_out */
+		priv->xs_power[2] = (long)cmpsu_xs_u16(data, 11) * 1000000; /* P_+12V */
+		priv->xs_power[3] = (long)cmpsu_xs_u16(data, 16) * 1000000; /* P_+3.3V */
+		priv->xs_power[4] = (long)cmpsu_xs_u16(data, 21) * 1000000; /* P_+5V */
+	} else if (data[0] == XS_REPORT_TEMP && size == XS_LEN_TEMP) {
+		/* hotspot temperature in degC -> millidegree */
+		priv->xs_temp[0] = (long)data[1] * 1000;
+	}
+}
+
+/* ============================== shared =============================== */
+
 static int cmpsu_probe(struct hid_device *hdev, const struct hid_device_id *id)
 {
 	struct cmpsu_data *priv;
+	const struct hwmon_chip_info *chip;
 	int ret;
 	int i;
-	
+
 	priv = devm_kzalloc(&hdev->dev, sizeof(struct cmpsu_data), GFP_KERNEL);
 	if (!priv)
 		return -ENOMEM;
-	
+
+	priv->proto = id->driver_data;
+
 	ret = hid_parse(hdev);
 	if (ret)
 		return ret;
-	
+
 	ret = hid_hw_start(hdev, HID_CONNECT_HIDRAW);
 	if (ret)
 		return ret;
-	
+
 	ret = hid_hw_open(hdev);
 	if (ret)
 		return ret;
-	
+
 	priv->hdev = hdev;
 	hid_set_drvdata(hdev, priv);
 	hid_device_io_start(hdev);
-	
-	for (i = 0; i < COUNT_VOLTAGE; i++)
-		priv->values_voltage[i] = -1;
-	for (i = 0; i < COUNT_CURRENT; i++)
-		priv->values_current[i] = -1;
-	for (i = 0; i < COUNT_POWER; i++)
-		priv->values_power[i] = -1;
-	for (i = 0; i < COUNT_TEMP; i++)
-		priv->values_temp[i] = -1;
-	for (i = 0; i < COUNT_FAN; i++)
-		priv->values_fan[i] = -1;
-	
+
+	if (priv->proto == CMPSU_XSILENT) {
+		for (i = 0; i < XS_COUNT_VOLTAGE; i++)
+			priv->xs_in[i] = -1;
+		for (i = 0; i < XS_COUNT_CURRENT; i++)
+			priv->xs_curr[i] = -1;
+		for (i = 0; i < XS_COUNT_POWER; i++)
+			priv->xs_power[i] = -1;
+		for (i = 0; i < XS_COUNT_TEMP; i++)
+			priv->xs_temp[i] = -1;
+		chip = &cmpsu_xs_chip_info;
+	} else {
+		for (i = 0; i < COUNT_VOLTAGE; i++)
+			priv->values_voltage[i] = -1;
+		for (i = 0; i < COUNT_CURRENT; i++)
+			priv->values_current[i] = -1;
+		for (i = 0; i < COUNT_POWER; i++)
+			priv->values_power[i] = -1;
+		for (i = 0; i < COUNT_TEMP; i++)
+			priv->values_temp[i] = -1;
+		for (i = 0; i < COUNT_FAN; i++)
+			priv->values_fan[i] = -1;
+		chip = &cmpsu_chip_info;
+	}
+
 	priv->hwmon_dev = hwmon_device_register_with_info(&hdev->dev, "cmpsu",
-					priv, &cmpsu_chip_info, NULL);
+				priv, chip, NULL);
 	if (IS_ERR(priv->hwmon_dev)) {
 		ret = PTR_ERR(priv->hwmon_dev);
 		hid_hw_close(hdev);
 		hid_hw_stop(hdev);
 		return ret;
 	}
-	
+
 	return 0;
 }
 
 static void cmpsu_remove(struct hid_device *hdev)
 {
 	struct cmpsu_data *priv = hid_get_drvdata(hdev);
-	
+
 	hwmon_device_unregister(priv->hwmon_dev);
 	hid_hw_close(hdev);
 	hid_hw_stop(hdev);
 }
 
 static int cmpsu_raw_event(struct hid_device *hdev, struct hid_report *report,
-			u8 *data, int size)
+		u8 *data, int size)
 {
 	struct cmpsu_data *priv = hid_get_drvdata(hdev);
 	char type;
 	unsigned int channel;
 	unsigned int value1;
 	unsigned int value2;
-	
+
+	if (priv->proto == CMPSU_XSILENT) {
+		cmpsu_xs_parse(priv, data, size);
+		return 0;
+	}
+
+	/* ---- MasterPlus ASCII protocol (unchanged) ---- */
 	if (size != EVENT_LEN)
 		return 0;
-	
+
 	/* Make sure the data is null-terminated */
 	if (data[size - 1] != 0)
 		return 0;
@@ -332,7 +528,7 @@ static int cmpsu_raw_event(struct hid_device *hdev, struct hid_report *report,
 	 * (square brackets + data type + channel index + value) */
 	if (size < 5)
 		return 0;
-	
+
 	/* Pick the correct format string depending on the packet type */
 	switch (data[1]) {
 		/* Voltage, current, temperature: Single value with one decimal */
@@ -340,13 +536,13 @@ static int cmpsu_raw_event(struct hid_device *hdev, struct hid_report *report,
 		case 'I':
 		case 'T':
 			if (sscanf(data, "[%c%1u%03u.%1u]",
-						&type, &channel, &value1, &value2) != 4)
+					&type, &channel, &value1, &value2) != 4)
 				return 0;
 			break;
 		/* Fan RPM: Single value, no decimal */
 		case 'R':
 			if (sscanf(data, "[%c%1u%04u]",
-						&type, &channel, &value1) != 3)
+					&type, &channel, &value1) != 3)
 				return 0;
 			break;
 		/* Power: Two values, no decimal */
@@ -355,18 +551,18 @@ static int cmpsu_raw_event(struct hid_device *hdev, struct hid_report *report,
 			if (data[2] != '2')
 				return 0;
 			if (sscanf(data, "[%c%1u%04u/%04u]",
-						&type, &channel, &value1, &value2) != 4)
+					&type, &channel, &value1, &value2) != 4)
 				return 0;
 			break;
 		default:
 			return 0;
 	}
-	
+
 	if (channel < 0)
 		return 0;
 	/* Index from the device starts at 1 */
 	channel -= 1;
-	
+
 	switch (type) {
 		case 'V':
 			if (channel >= COUNT_VOLTAGE)
@@ -395,7 +591,7 @@ static int cmpsu_raw_event(struct hid_device *hdev, struct hid_report *report,
 			priv->values_power[1] = value2 * 1000000;
 			break;
 	}
-	
+
 	return 0;
 }
 
@@ -414,6 +610,8 @@ static const struct hid_device_id cmpsu_idtable[] = {
 	{ HID_USB_DEVICE(0x2516, 0x019F) }, /* V750 PLATINUM i 12VO */
 	{ HID_USB_DEVICE(0x2516, 0x01A1) }, /* V850 PLATINUM i 12VO */
 	{ HID_USB_DEVICE(0x2516, 0x01A5) }, /* FANLESS 1300 */
+	{ HID_USB_DEVICE(0x2516, 0x020C),   /* X SILENT Edge Platinum 1100 */
+	  .driver_data = CMPSU_XSILENT },
 	{ }
 };
 MODULE_DEVICE_TABLE(hid, cmpsu_idtable);

--- a/cm-psu.c
+++ b/cm-psu.c
@@ -9,8 +9,11 @@
  * X SILENT Edge Platinum support (PID 0x020C) added 2026.
  * That model speaks a DIFFERENT protocol than the MasterPlus devices:
  *  - Binary (not ASCII), little-endian values
- *  - Report 3 (23 bytes incl. report-id) = full telemetry, streamed by the
- *    device on its own (no request needed)
+ *  - The device stays SILENT after a power-cycle until it receives an arming
+ *    command: output report id 0x02 with a single data byte 0x04. After that
+ *    it streams telemetry on its own via the interrupt-in endpoint.
+ *    (Captured from HWiNFO/MasterCTRL traffic.)
+ *  - Report 3 (23 bytes incl. report-id) = full telemetry
  *  - Report 4 (2 bytes incl. report-id)  = hotspot temperature in degC
  * Layout of report 3 payload (data[1..22], data[0] = report id 0x03):
  *   [0,1] u16 Vin/10   [2] u8 Iin/10   [3,4] u16 Pin   [5,6] u16 Pout
@@ -26,6 +29,7 @@
 #include <linux/init.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/slab.h>
 #include <linux/types.h>
 
 /*
@@ -62,6 +66,11 @@ enum cmpsu_proto {
 #define XS_REPORT_TEMP 0x04
 #define XS_LEN_DATA    23
 #define XS_LEN_TEMP    2
+
+/* Arming command: device only starts streaming after we send this.
+ * Output report id 0x02, single data byte 0x04 (captured from HWiNFO). */
+#define XS_ARM_REPORT_ID 0x02
+#define XS_ARM_DATA_BYTE 0x04
 
 struct cmpsu_data {
 	struct hid_device *hdev;
@@ -401,6 +410,31 @@ static inline u16 cmpsu_xs_u16(const u8 *d, int i)
 	return d[i] | (d[i + 1] << 8);
 }
 
+/* Send the arming command so the PSU starts streaming telemetry reports.
+ * Without this, the device stays silent after a real power-cycle.
+ * hid_hw_output_report() routes to the interrupt-out endpoint if present
+ * (which this device has), otherwise to the control endpoint. */
+static int cmpsu_xs_arm(struct hid_device *hdev)
+{
+	u8 *buf;
+	int ret;
+
+	buf = kmalloc(2, GFP_KERNEL);
+	if (!buf)
+		return -ENOMEM;
+
+	buf[0] = XS_ARM_REPORT_ID;	/* report id 0x02 */
+	buf[1] = XS_ARM_DATA_BYTE;	/* data    0x04   */
+
+	ret = hid_hw_output_report(hdev, buf, 2);
+
+	kfree(buf);
+	if (ret < 0)
+		hid_warn(hdev, "cm-psu: X SILENT arming command failed: %d\n",
+			 ret);
+	return ret;
+}
+
 static void cmpsu_xs_parse(struct cmpsu_data *priv, u8 *data, int size)
 {
 	/* data[0] = report id; payload starts at data[1] */
@@ -468,6 +502,9 @@ static int cmpsu_probe(struct hid_device *hdev, const struct hid_device_id *id)
 		for (i = 0; i < XS_COUNT_TEMP; i++)
 			priv->xs_temp[i] = -1;
 		chip = &cmpsu_xs_chip_info;
+
+		/* Kick the device into streaming mode (see cmpsu_xs_arm) */
+		cmpsu_xs_arm(hdev);
 	} else {
 		for (i = 0; i < COUNT_VOLTAGE; i++)
 			priv->values_voltage[i] = -1;


### PR DESCRIPTION
Hi, thanks for this driver! I have an X SILENT Edge Platinum 1100 and reverse-engineered its protocol to add support.

# Add support for X SILENT Edge Platinum 1100 (PID 0x020C)

## Summary

This adds support for the **Cooler Master X SILENT Edge Platinum 1100**
(`2516:020c`), a fanless ATX 3.1 PSU from the newer "X Silent" line that is
managed by Cooler Master's **MasterCTRL** software (not the older MasterPlus).

The device binds to the existing driver once its PID is added, but reports
`N/A` for everything, because **it speaks a completely different protocol than
the MasterPlus devices** the driver was written for. Rather than the ASCII
`[{type}{channel}{value}]` strings, it streams **binary little-endian** reports.

The change keeps the MasterPlus path byte-for-byte unchanged and selects the
new code path per device via `hid_device_id.driver_data`.

## Protocol (reverse-engineered)

After a power-cycle the device stays silent on the interrupt-IN endpoint
until it receives an arming command: output report id 0x02 with a single
data byte 0x04. The driver sends this once from probe() (see cmpsu_xs_arm).
Without it, all values read N/A until the PSU has been initialized by Cooler
Master's software under Windows — and that armed state only survives a warm
reboot, not a cold boot, which is what made the behaviour confusing at first.

Once armed, the device streams Report 3 and Report 4 on the interrupt-IN
endpoint on its own (no per-read polling needed).

**Report 3** (23 bytes incl. report id `0x03`) — full telemetry.
Payload layout (`data[1..22]`):

| Offset | Field | Type | Scaling |
|--------|-------|------|---------|
| 0,1 | Input Voltage | u16 LE | ÷10 → V |
| 2 | Input Current | u8 | ÷10 → A |
| 3,4 | Input Power | u16 LE | W |
| 5,6 | Output Power | u16 LE | W |
| 7 | +12V Voltage | u8 | ÷10 → V |
| 8,9 | +12V Current | u16 LE | ÷10 → A |
| 10,11 | +12V Power | u16 LE | W |
| 12 | +3.3V Voltage | u8 | ÷10 → V |
| 13,14 | +3.3V Current | u16 LE | ÷10 → A |
| 15,16 | +3.3V Power | u16 LE | W |
| 17 | +5V Voltage | u8 | ÷10 → V |
| 18,19 | +5V Current | u16 LE | ÷10 → A |
| 20,21 | +5V Power | u16 LE | W |

Structure = input voltage (u16) followed by four 5-byte blocks of the form
`[scalar u8, u16 LE, u16 LE]` — block 0 is the AC side `[Iin, Pin, Pout]`,
blocks 1–3 are the rails `[V, I, P]`.

**Report 4** (2 bytes incl. report id `0x04`) — hotspot temperature in °C.

**Feature report 1** (6 bytes, GET_FEATURE) returns `01 00 01 00 00 06` =
firmware version 1.0.0.6 (not exposed as a sensor).

## How it was verified

- Captured MasterCTRL's USB traffic with USBPcap/Wireshark.
- Per-byte variance analysis across load changes to locate the live fields.
- Cross-checked every field against the values MasterCTRL **and** HWiNFO show.
- Sanity check `P = U × I` holds on every rail and across the full load range;
  computed efficiency stays at the expected ~90–91 %.
- Captured the arming command (0x02 0x04) via USBPcap while HWiNFO first
  initialized a cold device, and confirmed on Linux that sending it from the
  driver reliably starts the stream after any cold boot — no Windows needed.

Example (live, decoded by this driver vs. `sensors`):
```
V_AC 222.0 V | +12V 12.5 V | +3.3V 3.4 V | +5V 5.2 V | temp 41 °C
P_in 115 W | P_out 104 W (eff 90.4 %) | P_+12V 65 W | P_+3.3V 4 W | P_+5V 35 W
I_AC 0.5 A | I_+12V 5.2 A | I_+3.3V 1.2 A | I_+5V 6.9 A
```

## Implementation notes

- New `enum cmpsu_proto` stored in `priv->proto` from `id->driver_data`.
- Separate hwmon channel layout for X Silent: 4 voltages, 4 currents,
  5 powers, 1 temperature, **no fan** (the PSU is passive).
- `cmpsu_raw_event()` dispatches to a binary parser for the X Silent and to the
  unchanged ASCII parser otherwise.
- Probe registers the matching `hwmon_chip_info` based on `proto`.

## Open / minor

- Input/Output and the per-rail powers are read directly from the device
  (not derived), matching what MasterCTRL displays.
- A third single-byte input report (`0x05`, observed value 37) is **not**
  decoded. Neither MasterCTRL nor HWiNFO surface it; it is likely an unused
  second-sensor slot shared with another model in the same report layout.

## Testing

Tested on Fedora, kernel 7.0.11, device `2516:020c` (X SILENT Edge Platinum
1100). MasterPlus devices were not affected (their code path is unchanged); I
do not have a MasterPlus unit to re-test, but no MasterPlus logic was modified.